### PR TITLE
Issue #2: Add colour picker to Site Branding admin

### DIFF
--- a/src/assets/admin.py
+++ b/src/assets/admin.py
@@ -990,6 +990,17 @@ class SiteBrandingAdmin(ModelAdmin):
         "color_mode",
     ]
 
+    def formfield_for_dbfield(self, db_field, request, **kwargs):
+        if db_field.name in (
+            "primary_color",
+            "secondary_color",
+            "accent_color",
+        ):
+            from unfold.widgets import UnfoldAdminColorInputWidget
+
+            kwargs["widget"] = UnfoldAdminColorInputWidget
+        return super().formfield_for_dbfield(db_field, request, **kwargs)
+
     def has_add_permission(self, request):
         if SiteBranding.objects.exists():
             return False

--- a/src/assets/tests.py
+++ b/src/assets/tests.py
@@ -20983,3 +20983,37 @@ class TestSiteBrandingAdminFields:
         assert "secondary_color" in content
         assert "accent_color" in content
         assert "color_mode" in content
+
+
+class TestSiteBrandingColorPickerWidget:
+    """S4.6.2-04: Colour fields should use UnfoldAdminColorInputWidget."""
+
+    def test_color_fields_render_as_color_input(self, admin_client):
+        """Colour fields must render with type='color' HTML input."""
+        response = admin_client.get("/admin/assets/sitebranding/add/")
+        assert response.status_code == 200
+        content = response.content.decode()
+        for field in ["primary_color", "secondary_color", "accent_color"]:
+            assert (
+                'type="color"' in content
+                and 'name="{}"'.format(field) in content
+            ), f"{field} should render as a color picker input"
+
+    def test_color_picker_saves_value(self, admin_client):
+        """Colour value submitted via picker persists correctly."""
+        response = admin_client.post(
+            "/admin/assets/sitebranding/add/",
+            {
+                "primary_color": "#BC2026",
+                "secondary_color": "#4A708B",
+                "accent_color": "#2D7A6D",
+                "color_mode": "system",
+            },
+            follow=True,
+        )
+        assert response.status_code == 200
+        branding = SiteBranding.objects.first()
+        assert branding is not None
+        assert branding.primary_color == "#BC2026"
+        assert branding.secondary_color == "#4A708B"
+        assert branding.accent_color == "#2D7A6D"


### PR DESCRIPTION
Implements #2

## Summary
- Wires up django-unfold's built-in `UnfoldAdminColorInputWidget` for the `primary_color`, `secondary_color`, and `accent_color` fields in the Site Branding admin
- Replaces plain text hex inputs with HTML5 colour pickers styled to match the unfold admin theme
- No model changes, no new dependencies, no custom JavaScript

## Changes
- `src/assets/admin.py` — Override `formfield_for_dbfield()` in `SiteBrandingAdmin` to use the colour picker widget for colour fields
- `src/assets/tests.py` — Add `TestSiteBrandingColorPickerWidget` with 2 tests:
  - `test_color_fields_render_as_color_input` — verifies `type="color"` HTML inputs render
  - `test_color_picker_saves_value` — verifies colour values persist correctly

## Test Coverage
- 2 new tests, all 1335 tests pass
- Pre-commit hooks (black, isort, flake8) pass

---
*Created by spec-pipeline*